### PR TITLE
Updated ipython_version.t to reflect current jupyter/ipython output

### DIFF
--- a/t/ipython_version.t
+++ b/t/ipython_version.t
@@ -5,12 +5,24 @@ use File::Which;
 
 plan tests => 2;
 
+my $version;
 my ($ipython) = grep { -x which($_) } qw(jupyter ipython ipython3 ipython2);
 
 ok( defined $ipython, "Found ipython: $ipython");
 
-my $version = qx|$ipython --version|;
+# run either the jupyter command which outputs more information, or the ipython commands which just outputs a version
+if ($ipython =~ /jupyter/) {
+  $version = qx/$ipython --version | grep ipython /;
+ } else {
+  $version = qx/$ipython --version /;
+ }
+chomp($version);
+
 $version =~ s/-dev$//; # remove dev suffix
-ok( version->parse($version) >= version->parse(1.0), 'IPython frontend version must be >= 1.0' );
+
+# modern ipython has version like x.y.z, so we need to remove the last \. and any cruft ahead of that
+$version =~ s/.*?(\d+)\.(\d+)\.(\d+)/\1\.\2\3/g;
+
+ok( $version >= 1.0 , 'IPython frontend version must be >= 1.0' );
 
 done_testing;


### PR DESCRIPTION
Modern ipython outputs information like this

```
ipython --version
7.6.1
```

And jupyter

```
jupyter --version
jupyter core     : 4.5.0
jupyter-notebook : 5.7.8
qtconsole        : 4.5.1
ipython          : 7.6.1
ipykernel        : 5.1.1
jupyter client   : 5.3.0
jupyter lab      : not installed
nbconvert        : 5.5.0
ipywidgets       : 7.5.0
nbformat         : 4.4.0
traitlets        : 4.3.2
```

This patch adjusts the ipython_version.t test to correctly handle the modern output formats.